### PR TITLE
Add `LayerVersion` to outputs

### DIFF
--- a/package-sam.yml
+++ b/package-sam.yml
@@ -12,3 +12,7 @@ Resources:
             RetentionPolicy: Retain
             LicenseInfo: MIT
           
+Outputs:
+    LayerVersion:
+        Description: Layer ARN Reference
+        Value: !Ref NodeCanvasLayer


### PR DESCRIPTION
This will allow to easily import this layer into other templates or CDK stacks:

```ts
const canvasLayer = new CfnApplication(this, "NodeCanvasLayer", {
  location: {
    applicationId:
      "arn:aws:serverlessrepo:us-east-1:990551184979:applications/lambda-layer-canvas-nodejs",
    semanticVersion: "2.9.1"
  }
});

const nodeCanvasLayerVersion = LayerVersion.fromLayerVersionArn(
  this,
  "NodeCanvasLayerVersion",
  canvasLayer.getAtt("Outputs.LayerVersion").toString()
);
```
